### PR TITLE
Move search to query params

### DIFF
--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -1,6 +1,6 @@
 import Head from "next/head";
 import Script from "next/script";
-import { useState } from "react";
+import {useRouter, usePathname, useSearchParams } from "next/navigation";
 import Footer from "../components/footer";
 import SearchBox from "../components/searchBox";
 import SearchHandler from "../components/searchHandler";
@@ -10,7 +10,21 @@ const DESCRIPTION =
   "Seach GIFs fast! Zero ads, super fast results, click and drag into emails or one click download/copy markdown for your blog or GitHub comments!";
 
 export default function Home() {
-  const [searchValue, setSearchValue] = useState("");
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const setSearchValue = (text: string) => {
+      if (text == "") {
+          router.push(pathname)
+          return
+      }
+      const params = new URLSearchParams();
+      params.set("search", text);
+      router.push(pathname + "?" + params.toString());
+  }
+
+  const searchParams = useSearchParams();
+  const searchValue = searchParams.get("search") ?? "";
   const searchTerm = searchValue.trim();
 
   return (


### PR DESCRIPTION
Rather than tracking the search parameters in react state, lets use the url search params to track the search. Doing this allows users to type in urls that put them directly into a search. For example, if the user directly navigates to `popcorngifsearch.com/?search=big%20lebowski`, they will immediately land on a page with the gif search results for "big lebowski".

This is useful when using something like [go
links](https://www.golinks.io). A go link can be created in which the search term is provided via a variable. One can image a go link like `go/gif/<search-term>`. The link could then direct to `popcorngifsearch.com/?search=<search-term>`.