### PR TITLE
Fix Downloads Check

### DIFF
--- a/app/utils/download.ts
+++ b/app/utils/download.ts
@@ -2,7 +2,7 @@ declare const chrome: any;
 
 export default class Download {
   static isSupported() {
-    return chrome && chrome.downloads && chrome.downloads.download;
+    return typeof chrome !== 'undefined' && chrome?.downloads?.download !== undefined;
   }
 
   static download(url: string, filename: string) {


### PR DESCRIPTION
When running in firefox, if we search we get the following error:

```
ReferenceError: chrome is not defined
```

According to this [Stack Overflow post][sopost], Firefox got rid of the `browser` and `chrome` property a while ago (not sure if this is true since the [MDN docs][mdn] still have them)

I think we can also simplify the expression overall.

[sopost]: https://stackoverflow.com/questions/64330672/referenceerror-browser-is-not-defined
[mdn]: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API